### PR TITLE
Support redux saga v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-ops",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "description": "A library for redux saga asynchronous calls",
   "main": "./dist/index.js",
   "repository": "https://github.com/autodatadirect/async-ops",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-ops",
-  "version": "1.1.6",
+  "version": "1.1.8",
   "description": "A library for redux saga asynchronous calls",
   "main": "./dist/index.js",
   "repository": "https://github.com/autodatadirect/async-ops",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "standard": "13.1.0"
   },
   "peerDependencies": {
-    "redux-saga": "0.16.0"
+    "redux-saga": "0.16.0 || ^1.0.0"
   },
   "standard": {
     "parser": "babel-eslint"

--- a/src/saga.js
+++ b/src/saga.js
@@ -27,7 +27,7 @@ function * loader (action) {
     try {
       yield put(responseAction)
     } catch (e) {
-      // redux-saga v0.16 swallows put() exceptions
+      // redux-saga v0.16 swallows put() exceptions. Ensure v1 behaves the same.
     }
   } catch (error) {
     const errorAction = {
@@ -39,7 +39,7 @@ function * loader (action) {
     try {
       yield put(errorAction)
     } catch (e) {
-      // redux-saga v0.16 swallows put() exceptions
+      // redux-saga v0.16 swallows put() exceptions. Ensure v1 behaves the same.
     }
   }
 }

--- a/src/saga.js
+++ b/src/saga.js
@@ -24,7 +24,11 @@ function * loader (action) {
       response
     }
 
-    yield put(responseAction)
+    try {
+      yield put(responseAction)
+    } catch (e) {
+      // redux-saga v0.16 swallows put() exceptions
+    }
   } catch (error) {
     const errorAction = {
       ...responseObject,
@@ -32,6 +36,10 @@ function * loader (action) {
       error
     }
 
-    yield put(errorAction)
+    try {
+      yield put(errorAction)
+    } catch (e) {
+      // redux-saga v0.16 swallows put() exceptions
+    }
   }
 }


### PR DESCRIPTION
> [`redux-saga` is well-tested and v1 is only a small iteration over v0.16](https://github.com/redux-saga/redux-saga/issues/1908#issuecomment-520812464)

And none of the changes appear to be breaking for us: https://github.com/redux-saga/redux-saga/releases/tag/v1.0.0
Except possibly for the `put()` exceptions, which should be resolved by catching them manually